### PR TITLE
remove deployment section from laravel

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -204,7 +204,6 @@
         * [Model Relationships](content/laravel/more-features/db-relationships.md)
         * [Query Builder](content/laravel/more-features/db-query-builder.md)
         * [Additional Features](content/laravel/more-features/reddit.md)
-    * [Deploying](content/laravel/more-features/deploying.md)
 * [Appendix A: Angular](content/angular/README.md)
     * [Expressions and Directives](content/angular/templating.md)
     * [Models](content/angular/models.md)


### PR DESCRIPTION
We now deploy with warpspeed and the ansible scripts referenced in the
deployment lesson are out of date.
