### PR TITLE
add examples directory to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "Jason Straughan <jason@codeup.com>",
     "Ben Batschelet <ben@codeup.com>",
     "Isaac Castillo <isaac@codeup.com>",
-    "Thomas Laffoon <thomas@codeup.com>"
+    "Thomas Laffoon <thomas@codeup.com>",
+    "Zach Gulde <zach@codeup.com>"
   ],
   "license": "Proprietary",
   "private": true,
@@ -20,7 +21,7 @@
   "scripts": {
     "install": "gitbook install book",
     "serve": "gitbook serve book --no-live",
-    "build": "gitbook build book build"
+    "build": "gitbook build book build; cp -r book/content/examples build/"
   },
   "engines": {
     "node": "7.7.1"


### PR DESCRIPTION
It looks like the old version of gitbook was copying over our examples
directory without being told to (even though none of those files are
linked in the SUMMARY.md), but the new version will not do this, so
we'll have to specify it ourselves

also add myself to the contributors